### PR TITLE
aries: Enable simple PowerHAL for native double-tap-to-wake

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -23,3 +23,6 @@ BOARD_KERNEL_CMDLINE += mem=1756M
 #BOARD_KERNEL_CMDLINE += mem=90M@0 mem=1666M@255M
 
 PRODUCT_VENDOR_KERNEL_HEADERS += device/sony/aries/kernel-headers
+
+TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"
+TARGET_TAP_TO_WAKE_STRING := true


### PR DESCRIPTION
Signed-off-by: Adam Farden <adam@farden.cz>
Signed-off-by: David Viteri <davidteri91@gmail.com>