### PR TITLE
aries: Update NFC NXP HAL naming

### DIFF
--- a/aosp_d5803.mk
+++ b/aosp_d5803.mk
@@ -67,6 +67,10 @@ PRODUCT_COPY_FILES += \
     device/sony/aries/rootdir/system/etc/tfa98xx/VoiceCallEarpice_top.preset:/system/etc/tfa98xx/VoiceCallEarpice_top.preset \
     device/sony/aries/rootdir/system/etc/tfa98xx/VoiceCallEarpice_top.eq:/system/etc/tfa98xx/VoiceCallEarpice_top.eq
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.aries
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=aries
+
 PRODUCT_NAME := aosp_d5803
 PRODUCT_DEVICE := aries
 PRODUCT_MODEL := Xperia Z3 Compact (AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba <humberos@gmail.com>